### PR TITLE
Updates to use Pathlib rather than str or os.path

### DIFF
--- a/hermes_merit/__init__.py
+++ b/hermes_merit/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under Apache License v2 - see LICENSE.rst
-import os.path
+from pathlib import Path
 
 from hermes_core import log
 from hermes_merit.io.file_tools import read_file
@@ -19,7 +19,7 @@ INST_TARGETNAME = "MERIT"
 INST_TO_SHORTNAME = {INST_NAME: INST_SHORTNAME}
 INST_TO_TARGETNAME = {INST_NAME: INST_TARGETNAME}
 
-_package_directory = os.path.dirname(os.path.abspath(__file__))
-_data_directory = os.path.abspath(os.path.join(_package_directory, "data"))
+_package_directory = Path(__file__).parent
+_data_directory = _package_directory / "data"
 
 log.info(f"hermes_merit version: {__version__}")

--- a/hermes_merit/calibration/calibration.py
+++ b/hermes_merit/calibration/calibration.py
@@ -204,7 +204,7 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
 def get_calibration_file(data_filename: Path, time=None) -> Path:
     """
     Given a time, return the appropriate calibration file.
-    
+
     Parameters
     ----------
     data_filename: `pathlib.Path`

--- a/hermes_merit/calibration/calibration.py
+++ b/hermes_merit/calibration/calibration.py
@@ -167,10 +167,9 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
     ----------
     data: dict
         A dictionary of arrays which includes the ccsds header fields
-        original_filename: `pathlib.Path`
+    original_filename: `pathlib.Path`
         The Path to the originating file.
-    destination_dir: `pathlib.Path`
-        The directory where the output file will be written.
+
     Returns
     -------
     output_filename: `pathlib.Path`
@@ -205,6 +204,7 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
 def get_calibration_file(data_filename: Path, time=None) -> Path:
     """
     Given a time, return the appropriate calibration file.
+    
     Parameters
     ----------
     data_filename: `pathlib.Path`

--- a/hermes_merit/calibration/calibration.py
+++ b/hermes_merit/calibration/calibration.py
@@ -3,7 +3,6 @@ A module for all things calibration.
 """
 
 import random
-import os.path
 from pathlib import Path
 
 import ccsdspy
@@ -31,13 +30,14 @@ def process_file(data_filename: Path) -> list:
 
     Parameters
     ----------
-    data_filename: str
-        Fully specificied filename of an input file
+    data_filename: `pathlib.Path`
+        Fully specificied filename of an input file.
+        The file contents: Traditional binary packets in CCSDS format
 
     Returns
     -------
-    output_filenames: list
-        Fully specificied filenames for the output files.
+    output_filenames: `list[pathlib.Path]`
+        Fully specificied filenames for the output CDF files.
     """
     log.info(f"Processing file {data_filename}.")
     output_files = []
@@ -58,12 +58,12 @@ def calibrate_file(data_filename: Path) -> Path:
 
     Parameters
     ----------
-    data_filename: Path
+    data_filename: `pathlib.Path`
         Fully specificied filename of the input data file.
 
     Returns
     -------
-    output_filename: Path
+    output_filename: `pathlib.Path`
         Fully specificied filename of the output file.
 
     Examples
@@ -136,7 +136,7 @@ def parse_l0_sci_packets(data_filename: Path) -> dict:
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         Fully specificied filename
 
     Returns
@@ -153,7 +153,7 @@ def parse_l0_sci_packets(data_filename: Path) -> dict:
     log.info(f"Parsing packets from file:{data_filename}.")
 
     pkt = ccsdspy.FixedLength.from_file(
-        os.path.join(hermes_merit._data_directory, "MERIT_sci_packet_def.csv")
+        Path(hermes_merit._data_directory) / "MERIT_sci_packet_def.csv"
     )
     data = pkt.load(data_filename)
     return data
@@ -167,12 +167,13 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
     ----------
     data: dict
         A dictionary of arrays which includes the ccsds header fields
-    original_filename: Path
+        original_filename: `pathlib.Path`
         The Path to the originating file.
-
+    destination_dir: `pathlib.Path`
+        The directory where the output file will be written.
     Returns
     -------
-    output_filename: Path
+    output_filename: `pathlib.Path`
         Fully specificied filename of cdf file
 
     Examples
@@ -204,16 +205,15 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
 def get_calibration_file(data_filename: Path, time=None) -> Path:
     """
     Given a time, return the appropriate calibration file.
-
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         Fully specificied filename of the non-calibrated file (data level < 2)
     time: ~astropy.time.Time
 
     Returns
     -------
-    calib_filename: str
+    calib_filename: `pathlib.Path`
         Fully specificied filename for the appropriate calibration file.
 
     Examples
@@ -228,12 +228,12 @@ def read_calibration_file(calib_filename: Path):
 
     Parameters
     ----------
-    calib_filename: str
+    calib_filename: `pathlib.Path`
         Fully specificied filename of the non-calibrated file (data level < 2)
 
     Returns
     -------
-    output_filename: str
+    output_filename: `pathlib.Path`
         Fully specificied filename of the appropriate calibration file.
 
     Examples

--- a/hermes_merit/io/file_tools.py
+++ b/hermes_merit/io/file_tools.py
@@ -11,7 +11,7 @@ def read_file(data_filename):
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         A file to read.
 
     Returns

--- a/hermes_merit/io/file_tools.py
+++ b/hermes_merit/io/file_tools.py
@@ -2,10 +2,12 @@
 This module provides a generic file reader.
 """
 
+from pathlib import Path
+
 __all__ = ["read_file"]
 
 
-def read_file(data_filename):
+def read_file(data_filename: Path):
     """
     Read a file.
 

--- a/hermes_merit/tests/test_calibration.py
+++ b/hermes_merit/tests/test_calibration.py
@@ -1,5 +1,4 @@
 import pytest
-import os.path
 from pathlib import Path
 
 import hermes_merit.calibration as calib

--- a/hermes_merit/tests/test_file_tools.py
+++ b/hermes_merit/tests/test_file_tools.py
@@ -1,5 +1,6 @@
+from pathlib import Path
 from hermes_merit.io.file_tools import read_file
 
 
 def test_read_file():
-    assert read_file("test_file.cdf") is None
+    assert read_file(Path("test_file.cdf")) is None


### PR DESCRIPTION
This PR updates the HERMES MERIT processing functionality to consistently use pathlib.Path objects for file paths when processing files. Previously these functions used str objects or os.path, which goes against the HERMES best-practices. This PR aligns the functionality of the package with the best practices defined for the mission code development.